### PR TITLE
fix: move text field labels to the string resource file

### DIFF
--- a/app/src/main/java/com/example/erims_app/MainActivity.kt
+++ b/app/src/main/java/com/example/erims_app/MainActivity.kt
@@ -7,9 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.ui.Modifier
-import com.example.erims_app.ui.components.CustomDatePicker
+import com.example.erims_app.ui.screens.employee.EmployeeEntryScreen
 import com.example.erims_app.ui.theme.ERIMSAppTheme
 
 class MainActivity : ComponentActivity() {
@@ -22,8 +21,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    val datePickerState = rememberDatePickerState()
-                    CustomDatePicker(datePickerState = datePickerState)
+                    EmployeeEntryScreen()
                 }
             }
         }

--- a/app/src/main/java/com/example/erims_app/ui/components/CustomDatePicker.kt
+++ b/app/src/main/java/com/example/erims_app/ui/components/CustomDatePicker.kt
@@ -37,7 +37,11 @@ import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CustomDatePicker(datePickerState: DatePickerState) {
+fun CustomDatePicker(
+    datePickerState: DatePickerState,
+    dateFormat: String,
+    dateLabel: String
+) {
     Box(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.surfaceVariant)
@@ -61,11 +65,11 @@ fun CustomDatePicker(datePickerState: DatePickerState) {
                 modifier = Modifier.weight(1f),
                 text = if (datePickerState.selectedDateMillis != null) {
                     SimpleDateFormat(
-                        stringResource(R.string.date_format),
+                        dateFormat,
                         Locale.getDefault()
                     ).format(datePickerState.selectedDateMillis)
                 } else {
-                    "Choose Date"
+                    dateLabel
                 },
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -125,6 +129,10 @@ fun ShowDateDialog(
 fun DatePickerPreview() {
     val datePickerState = rememberDatePickerState()
     ERIMSAppTheme {
-        CustomDatePicker(datePickerState = datePickerState)
+        CustomDatePicker(
+            datePickerState = datePickerState,
+            dateFormat = stringResource(R.string.date_format),
+            dateLabel = "Choose Date"
+        )
     }
 }

--- a/app/src/main/java/com/example/erims_app/ui/screens/employee/EmployeeEntryScreen.kt
+++ b/app/src/main/java/com/example/erims_app/ui/screens/employee/EmployeeEntryScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.erims_app.R
+import com.example.erims_app.ui.components.CustomDatePicker
 import com.example.erims_app.ui.theme.ERIMSAppTheme
 
 @Composable
@@ -32,6 +34,8 @@ fun EmployeeBody() {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun EmployeeForm(modifier: Modifier = Modifier) {
+    val datePickerState = rememberDatePickerState()
+
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.medium_padding))
@@ -39,7 +43,7 @@ private fun EmployeeForm(modifier: Modifier = Modifier) {
         TextField(
             value = "",
             onValueChange = {},
-            label = { Text(text = "First name") },
+            label = { Text(text = stringResource(R.string.first_name)) },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
             colors = TextFieldDefaults.colors(
@@ -50,7 +54,7 @@ private fun EmployeeForm(modifier: Modifier = Modifier) {
         TextField(
             value = "",
             onValueChange = {},
-            label = { Text(text = "Last name") },
+            label = { Text(text = stringResource(R.string.last_name)) },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
             colors = TextFieldDefaults.colors(
@@ -58,20 +62,15 @@ private fun EmployeeForm(modifier: Modifier = Modifier) {
             ),
             modifier = Modifier.fillMaxWidth()
         )
-        TextField(
-            value = "",
-            onValueChange = {},
-            label = { Text(text = "Date of birth") },
-            singleLine = true,
-            colors = TextFieldDefaults.colors(
-                unfocusedIndicatorColor = MaterialTheme.colorScheme.surfaceVariant
-            ),
-            modifier = Modifier.fillMaxWidth()
+        CustomDatePicker(
+            datePickerState = datePickerState,
+            dateFormat = stringResource(R.string.date_format),
+            dateLabel = stringResource(R.string.date_of_birth)
         )
         TextField(
             value = "",
             onValueChange = {},
-            label = { Text(text = "Job title") },
+            label = { Text(text = stringResource(R.string.job_title)) },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             colors = TextFieldDefaults.colors(
@@ -82,7 +81,7 @@ private fun EmployeeForm(modifier: Modifier = Modifier) {
         TextField(
             value = "",
             onValueChange = {},
-            label = { Text(text = "Salary") },
+            label = { Text(text = stringResource(R.string.salary)) },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
             colors = TextFieldDefaults.colors(
@@ -90,8 +89,6 @@ private fun EmployeeForm(modifier: Modifier = Modifier) {
             ),
             modifier = Modifier.fillMaxWidth()
         )
-        val datePickerState = rememberDatePickerState()
-        //TransactionDatePicker(datePickerState = datePickerState)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,9 @@
     <string name="date_picker_dialog_OK">OK</string>
     <string name="date_picker_dialog_DISMISS">Dismiss</string>
     <string name="date_format">MMMM d, yyyy</string>
+    <string name="first_name">First Name</string>
+    <string name="last_name">Last Name</string>
+    <string name="date_of_birth">Date of birth</string>
+    <string name="job_title">Job title</string>
+    <string name="salary">Salary</string>
 </resources>


### PR DESCRIPTION
I've added the label text of the text fields to the string resource file to use them for translation.